### PR TITLE
Find package version on-demand

### DIFF
--- a/embreex/__init__.py
+++ b/embreex/__init__.py
@@ -1,3 +1,9 @@
-from importlib.metadata import version as _get_version
+def __getattr__(name: str):
+    global __version__
 
-__version__ = _get_version("embreex")
+    if name == "__version__":
+        from importlib.metadata import version as _get_version
+
+        __version__ = _get_version("embreex")  # cache in module dict
+        return __version__
+    raise AttributeError(name)


### PR DESCRIPTION
Instead of on import, improving import speeds for the vast majority of use-cases. Found value is cached after first lookup.