### PR TITLE
fix: clear hit attributes on rays that miss

### DIFF
--- a/embreex/rtcore_scene.pyx
+++ b/embreex/rtcore_scene.pyx
@@ -119,14 +119,28 @@ cdef class EmbreeScene:
                         else:
                             tfars[i] = rayhit.ray.tfar
                     else:
-                        primID_arr[i] = -1 if rayhit.hit.primID == INVALID_GEOMETRY_ID else <int>rayhit.hit.primID
-                        geomID_arr[i] = -1 if rayhit.hit.geomID == INVALID_GEOMETRY_ID else <int>rayhit.hit.geomID
-                        u_arr[i] = rayhit.hit.u
-                        v_arr[i] = rayhit.hit.v
                         tfars[i] = rayhit.ray.tfar
-                        Ng_arr[i, 0] = rayhit.hit.Ng_x
-                        Ng_arr[i, 1] = rayhit.hit.Ng_y
-                        Ng_arr[i, 2] = rayhit.hit.Ng_z
+                        if rayhit.hit.primID == INVALID_GEOMETRY_ID:
+                            # Embree writes the hit fields only when a ray hits
+                            # something, and `rayhit` is reused across the loop,
+                            # so on a miss `rayhit.hit` still describes whichever
+                            # ray hit something last. Report zeros instead of
+                            # leaking that previous ray's surface.
+                            primID_arr[i] = -1
+                            geomID_arr[i] = -1
+                            u_arr[i] = 0.0
+                            v_arr[i] = 0.0
+                            Ng_arr[i, 0] = 0.0
+                            Ng_arr[i, 1] = 0.0
+                            Ng_arr[i, 2] = 0.0
+                        else:
+                            primID_arr[i] = <int>rayhit.hit.primID
+                            geomID_arr[i] = -1 if rayhit.hit.geomID == INVALID_GEOMETRY_ID else <int>rayhit.hit.geomID
+                            u_arr[i] = rayhit.hit.u
+                            v_arr[i] = rayhit.hit.v
+                            Ng_arr[i, 0] = rayhit.hit.Ng_x
+                            Ng_arr[i, 1] = rayhit.hit.Ng_y
+                            Ng_arr[i, 2] = rayhit.hit.Ng_z
                 else:
                     rtcOccluded1(self.scene_i, &rayhit.ray, NULL)
                     # In Embree 4, occlusion is signaled by setting ray.tfar to -inf

--- a/tests/test_intersection.py
+++ b/tests/test_intersection.py
@@ -205,6 +205,47 @@ class TestIntersectionHexahedron(TestCase):
         self.assertTrue(np.allclose([0.8, 0.6], v))
 
 
+class TestMissedRayOutput(TestCase):
+    def setUp(self):
+        triangles = np.array(xplane(7.0), "float32")
+        self.scene = rtcs.EmbreeScene()
+        TriangleMesh(self.scene, triangles)
+        # rays 0-2 hit the plane, ray 3 (y = -8.2) misses it
+        self.origins, self.dirs = define_rays_origins_and_directions()
+
+    def test_missed_rays_report_zero_hit_attributes(self):
+        """A ray that hits nothing must not report the previous ray's surface.
+
+        Embree fills the hit fields only on a hit, and the `RTCRayHit` is reused
+        for every ray in the batch, so without explicitly clearing them a missed
+        ray inherits whatever the last hit left behind.
+        """
+        res = self.scene.run(self.origins, self.dirs, output=1)
+
+        miss = res["primID"] == -1
+        self.assertEqual(miss.sum(), 1)
+        self.assertTrue(np.all(res["geomID"][miss] == -1))
+        self.assertTrue(np.all(res["u"][miss] == 0.0))
+        self.assertTrue(np.all(res["v"][miss] == 0.0))
+        self.assertTrue(np.all(res["Ng"][miss] == 0.0))
+
+        # the hits must still carry real data
+        self.assertTrue(np.all(res["primID"][~miss] >= 0))
+        self.assertTrue(np.any(res["u"][~miss] != 0.0))
+
+    def test_missed_ray_output_is_independent_of_batch_order(self):
+        """Reordering the batch must not change any ray's own result."""
+        order = np.array([3, 0, 3, 1, 3, 2, 3], dtype=np.intp)
+        a = self.scene.run(self.origins, self.dirs, output=1)
+        b = self.scene.run(
+            np.ascontiguousarray(self.origins[order]),
+            np.ascontiguousarray(self.dirs[order]),
+            output=1,
+        )
+        for key in ("primID", "geomID", "u", "v", "tfar", "Ng"):
+            np.testing.assert_array_equal(a[key][order], b[key])
+
+
 class TestOccludedQuery(TestCase):
     def test_occluded(self):
         """Occluded query: hits return >= 0, misses return -1."""


### PR DESCRIPTION
While exploring batched ray intersection, I hit a bug in `EmbreeScene.run` when `output=True` with how `RTCRayHit` is reused across every ray in the batch. `rayhit` would be reused across rays and only partially cleared for each ray. `primID` and `geomID` are cleared but not `u`, `v`, or `Ng`, which still hold the previous ray's values. That means batch queries can report false surface data on misses.
This PR fixes this bug and introduces regression tests to prove the fix.

The code is written AI-assisted, but i have read and stand by all changes myself.